### PR TITLE
Camera smoothing

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
@@ -2301,10 +2301,10 @@ MonoBehaviour:
   inputSensitivity: 150
   zoomToAvoidLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 5009
   noClippingEverLayers:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 257
   collisionSphereRadius: 0.1
   translationSmoothing: 0.1
   programmerSettings:

--- a/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
@@ -1423,9 +1423,9 @@ RectTransform:
   m_Father: {fileID: 8546107602802554828}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 100, y: 100}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4055577921622168343
@@ -2295,31 +2295,29 @@ MonoBehaviour:
   cameraTarget: {fileID: 1512199468782888033}
   dollyCamera: {fileID: 1512199469109834488}
   belowPoint: {fileID: 1512199468572587539}
-  CameraMoveSpeed: 120
-  upperWorldClampAngle: 70
-  lowerWorldClampAngle: -89
-  upperRelativeClampAngle: 150
-  lowerRelativeClampAngle: 0
-  relativeZoomAngle: 30
-  inputSensitivity: 150
+  angleRelativeZoom: 0
+  buttonZoomMultiplier: 0.3
   invertY: 1
-  minDistance: 0.4
-  maxDistance: 2
-  sphereLayers:
+  inputSensitivity: 150
+  zoomToAvoidLayers:
     serializedVersion: 2
-    m_Bits: 1
-  collisionPadding: 0.9
-  smallSphereRadius: 0.1
-  largeSphereRadius: 0.2
-  rayLayers:
+    m_Bits: 0
+  noClippingEverLayers:
     serializedVersion: 2
-    m_Bits: 256
-  smooth: 10
-  dollyDirAdjusted: {x: 0, y: 0, z: 0}
-  dollyDistance: 0
-  finalInputX: 0
-  finalInputY: 0
-  DEBUGString: Null
+    m_Bits: 0
+  collisionSphereRadius: 0.1
+  translationSmoothing: 0.1
+  programmerSettings:
+    smooth: 10
+    upperWorldClampAngle: 70
+    lowerWorldClampAngle: -89
+    upperRelativeClampAngle: 150
+    lowerRelativeClampAngle: 0
+    relativeZoomAngle: 30
+    minDistance: 0.4
+    maxDistance: 2
+    collisionPadding: 0.9
+    largeSphereMultiplier: 2
 --- !u!1 &1512199468974199804
 GameObject:
   m_ObjectHideFlags: 0
@@ -2395,7 +2393,6 @@ GameObject:
   - component: {fileID: 1512199469109834495}
   - component: {fileID: 1512199469109834488}
   - component: {fileID: 1512199469109834489}
-  - component: {fileID: 1512199469109834494}
   m_Layer: 6
   m_Name: Camera Itt 2
   m_TagString: Untagged
@@ -2469,19 +2466,6 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1512199469109834491}
   m_Enabled: 1
---- !u!135 &1512199469109834494
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1512199469109834491}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.2
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1512199469122907708
 GameObject:
   m_ObjectHideFlags: 0
@@ -4344,9 +4328,9 @@ RectTransform:
   m_Father: {fileID: 8546107602802554828}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: 0, y: 100}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 100, y: 100}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4071071232490536845
@@ -4595,11 +4579,6 @@ PrefabInstance:
       objectReference: {fileID: 9100000, guid: b49e72312da20054892146212a2e8a96, type: 2}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 94e9a46b739fe9748b2e4f7f3b4bb235, type: 3}
---- !u!4 &1748193692052928541 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1170964989822522959, guid: 94e9a46b739fe9748b2e4f7f3b4bb235, type: 3}
-  m_PrefabInstance: {fileID: 577250832134630994}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6940316162488598638 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7517134867158003260, guid: 94e9a46b739fe9748b2e4f7f3b4bb235, type: 3}
@@ -4633,6 +4612,11 @@ Transform:
 --- !u!1 &343301903614202627 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 94e9a46b739fe9748b2e4f7f3b4bb235, type: 3}
+  m_PrefabInstance: {fileID: 577250832134630994}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1748193692052928541 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1170964989822522959, guid: 94e9a46b739fe9748b2e4f7f3b4bb235, type: 3}
   m_PrefabInstance: {fileID: 577250832134630994}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &6784778354969362308 stripped

--- a/Capstone-Game/Assets/Scripts/Player/CameraGimbal.cs
+++ b/Capstone-Game/Assets/Scripts/Player/CameraGimbal.cs
@@ -5,52 +5,67 @@ using UnityEngine;
 public class CameraGimbal : MonoBehaviour
 {
     [Header("References:")]
+    [Header("Usefull Settings:")]
     public GameObject cameraTarget;
     public Camera dollyCamera;
     public Transform belowPoint;
+
+    [Header("Control Settings:")]
+    [Tooltip("Uses 'zoom when at low angle' system when true, or 'button-toggle zoom' when false.")]
+    public bool angleRelativeZoom = false;
+    [Tooltip("The new maximum distance when the zoom toggle is pressed - larger to zoom out (e.g. 2), smaller to zoom in (e.g. 0.3).")]
+    public float buttonZoomMultiplier = 0.3f;
+    public bool invertY = false;
+    [Tooltip("Multiplier for input.")]
+    public float inputSensitivity = 150.0f;
+
+    [Header("Obstacle Avoidance Settings:")]
+    [Tooltip("Should contain layers of objects which have small and fiddly hitboxes, or which the player often goes around or under (e.g. chairs, trees, people).")]
+    public LayerMask zoomToAvoidLayers;
+    [Tooltip("Should contain layers of objects which are large, unmoving and well defined (e.g. the ground, rocks, houses).")]
+    public LayerMask noClippingEverLayers;
+    [Tooltip("Size of the virtual collision sphere around the camera - i.e. how close the camera can get to obstacles (shown with solid blue gizmo).")]
+    public float collisionSphereRadius = 0.1f;
+
+    [Header("Other Settings:")]
+    [Tooltip("Roughly the time it takes the camera to catch up to the players position/velocity. Higher means more smoothing.")]
+    [SerializeField, Range(0.0f, 1.0f)]
+    public float translationSmoothing = 0.1f;
 
     private Transform CamObj
     {
         get { return dollyCamera.transform; }
     }
 
-    [Header("Gimbal Settings:")]
-    public float CameraMoveSpeed = 120.0f;
-    public float upperWorldClampAngle = 70.0f;
-    public float lowerWorldClampAngle = -89.0f;
-    public float upperRelativeClampAngle = 150.0f;
-    public float lowerRelativeClampAngle = 0.0f;
-    public float relativeZoomAngle = 30.0f;
-    public float inputSensitivity = 150.0f;
-    public bool invertY = false;
+    public CameraProSettings programmerSettings = new CameraProSettings();
 
-    [Header("Dolly Settings:")]
-    public bool angleRelativeZoom = false;
-    public float buttonZoomMultiplier = 0.3f;
-    [SerializeField, Range(0.0f, 10.0f)]
-    public float minDistance = 1.0f;
-    [SerializeField, Range(0.0f, 10.0f)]
-    public float maxDistance = 4.0f;
-    public LayerMask sphereLayers;
-    public float collisionPadding = 0.9f;
-    public float smallSphereRadius = 1f;
-    public float largeSphereRadius = 2f;
+    [System.Serializable]
+    public class CameraProSettings
+    {
+        [Header("~~~ PROGRAMMER SETTINGS ~~~")]
+        [SerializeField, Range(0.0f, 30.0f)]
+        public float smooth = 10.0f;
+
+        [Header("Gimbal Settings:")]
+        public float upperWorldClampAngle = 70.0f;
+        public float lowerWorldClampAngle = -89.0f;
+        public float upperRelativeClampAngle = 150.0f;
+        public float lowerRelativeClampAngle = 0.0f;
+        public float relativeZoomAngle = 30.0f;
+
+        [Header("Dolly Settings:")]
+        [SerializeField, Range(0.0f, 10.0f)]
+        public float minDistance = 0.4f;
+        [SerializeField, Range(0.0f, 10.0f)]
+        public float maxDistance = 2f;
+        public float collisionPadding = 0.9f;
+        public float largeSphereMultiplier = 2f;
+    }
     
-    [Header("Shared Settings:")]
-    public LayerMask rayLayers;
-    [SerializeField, Range(0.0f, 30.0f)]
-    public float smooth = 10.0f;
-    [Tooltip("Roughly the time it takes the camera to catch up to the players position/velocity. Higher means more smoothing.")]
-    [SerializeField, Range(0.0f, 1.0f)]
-    public float translationSmoothing = 0.1f;
-
-    [Header("Public For Debug:")]
-    public Vector3 dollyDirAdjusted;
-    public float dollyDistance;
-    public float finalInputX;
-    public float finalInputY;
-
-    public string DEBUGString = "Null";
+    private Vector3 dollyDirAdjusted;
+    private float dollyDistance;
+    private float finalInputX;
+    private float finalInputY;
 
     public bool UseRelativeAngles
     {
@@ -91,8 +106,13 @@ public class CameraGimbal : MonoBehaviour
         finalInputX = inputX;
         finalInputY = inputY;
 
+        Vector3 oldPos = dollyCamera.transform.position;
 
-        rotY += finalInputX * inputSensitivity * Time.deltaTime;
+        //Y (Left Right)
+        float deltaY = finalInputX * inputSensitivity * Time.deltaTime;
+        rotY += deltaY;
+
+        //X (Up Down)
         if (finalInputY > 0 || PlayerCanSeeBelowPoint())
             rotX += finalInputY * inputSensitivity * Time.deltaTime;
 
@@ -101,15 +121,27 @@ public class CameraGimbal : MonoBehaviour
         else
             playerAngle = 0;
         float oldRelativeAngle = rotX + playerAngle;
-        float newRelativeAngle = Mathf.Clamp(oldRelativeAngle, lowerRelativeClampAngle, upperRelativeClampAngle);
-        float delta = newRelativeAngle - oldRelativeAngle;
-        rotX += delta;
-        rotX = Mathf.Clamp(rotX, lowerWorldClampAngle, upperWorldClampAngle);
+        float newRelativeAngle = Mathf.Clamp(oldRelativeAngle, programmerSettings.lowerRelativeClampAngle, programmerSettings.upperRelativeClampAngle);
+        float deltaX = newRelativeAngle - oldRelativeAngle;
+        deltaX = Mathf.Clamp(rotX + deltaX, programmerSettings.lowerWorldClampAngle, programmerSettings.upperWorldClampAngle) - rotX;
+        rotX += deltaX;
 
         Quaternion localRotation = Quaternion.Euler(rotX, rotY, 0.0f);
         transform.rotation = localRotation;
 
-        RotateToUnblockedPoint();
+        if (Vector3.Distance(dollyCamera.transform.position, oldPos) > collisionSphereRadius)
+        {
+            if (Physics.Linecast(oldPos, dollyCamera.transform.position, noClippingEverLayers))
+            {
+                rotY -= deltaY;
+                rotX -= deltaX;
+
+                localRotation = Quaternion.Euler(rotX, rotY, 0.0f);
+                transform.rotation = localRotation;
+            }
+        }
+
+        RotateToUnblockedPoint(deltaY);
     }
 
     /// <summary> Move the camera gameobject towards the target at the move speed. </summary>
@@ -123,46 +155,26 @@ public class CameraGimbal : MonoBehaviour
     {
         if (Input.GetMouseButton(2))
         {
-            return maxDistance * buttonZoomMultiplier;
+            return programmerSettings.maxDistance * buttonZoomMultiplier;
         }
 
-        return maxDistance;
+        return programmerSettings.maxDistance;
     }
 
     public float UpdateDollyAngleZoom()
     {
         //Cause the camera to zoom in if it is below the zoom angle.
-        float zoomedMax = maxDistance;
-        if ((rotX + playerAngle) < relativeZoomAngle)
+        float zoomedMax = programmerSettings.maxDistance;
+        if ((rotX + playerAngle) < programmerSettings.relativeZoomAngle)
         {
-            float range = maxDistance - minDistance;
-            float fraction = 1 - (((rotX + playerAngle) - relativeZoomAngle) / (lowerRelativeClampAngle - relativeZoomAngle));
-            zoomedMax = minDistance + range * fraction;
+            float range = programmerSettings.maxDistance - programmerSettings.minDistance;
+            float fraction = 1 - (((rotX + playerAngle) - programmerSettings.relativeZoomAngle) / (programmerSettings.lowerRelativeClampAngle - programmerSettings.relativeZoomAngle));
+            zoomedMax = programmerSettings.minDistance + range * fraction;
         }
 
         desiredCameraPos = transform.TransformPoint(dollyDir * zoomedMax);
 
         return zoomedMax;
-
-        //Move the camera closer if certain bad conditions are found:
-        RaycastHit hit;
-        if (Physics.Linecast(transform.position, desiredCameraPos, out hit, rayLayers.value))
-        { //If line of sight is blocked by the specified layer(s), move in quickly (10x smooth speed).
-            dollyDistance = Mathf.Clamp((hit.distance - collisionPadding), minDistance, zoomedMax);
-            if (hit.collider.CompareTag("CameraSolid"))
-                CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth * 10);
-        }
-        else if (Physics.CheckSphere(CamObj.position, smallSphereRadius, sphereLayers.value))
-        { //If the camera is VERY near or inside an object in specified layer(s), move in at a smooth speed.
-            dollyDistance = Mathf.Clamp(dollyDistance - Time.deltaTime * smooth, minDistance, zoomedMax);
-            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth);
-        }
-        else if (!Physics.CheckSphere(CamObj.position, largeSphereRadius, sphereLayers.value))
-        { //If the camera is NOT near any specified objects, move out again at the smooth speed.
-            //(MUST be defined by a larger sphere than the previous check to prevent flickering)
-            dollyDistance = zoomedMax;
-            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth);
-        }
     }
 
     /// <summary> Adjust the distance between the camera and the rotation parent based on the angle and nearby obstacles. </summary>
@@ -180,49 +192,54 @@ public class CameraGimbal : MonoBehaviour
 
         //Move the camera closer if certain bad conditions are found:
         RaycastHit hit;
-        if (Physics.Linecast(transform.position, desiredCameraPos, out hit, rayLayers.value))
+        if (Physics.Linecast(transform.position, desiredCameraPos, out hit, zoomToAvoidLayers.value))
         { //If line of sight is blocked by the specified layer(s), move in quickly (10x smooth speed).
-            dollyDistance = Mathf.Clamp((hit.distance - collisionPadding), minDistance, zoomedMax);
+            dollyDistance = Mathf.Clamp((hit.distance - programmerSettings.collisionPadding), programmerSettings.minDistance, zoomedMax);
             if (hit.collider.CompareTag("CameraSolid"))
-                CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth * 10);
+                CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * programmerSettings.smooth * 10);
         }
-        else if (Physics.CheckSphere(CamObj.position, smallSphereRadius, sphereLayers.value))
+        else if (Physics.CheckSphere(CamObj.position, collisionSphereRadius, zoomToAvoidLayers.value))
         { //If the camera is VERY near or inside an object in specified layer(s), move in at a smooth speed.
-            dollyDistance = Mathf.Clamp(dollyDistance - Time.deltaTime * smooth, minDistance, zoomedMax);
-            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth);
+            dollyDistance = Mathf.Clamp(dollyDistance - Time.deltaTime * programmerSettings.smooth, programmerSettings.minDistance, zoomedMax);
+            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * programmerSettings.smooth);
         }
-        else if (!Physics.CheckSphere(CamObj.position, largeSphereRadius, sphereLayers.value))
+        else if (!Physics.CheckSphere(CamObj.position, collisionSphereRadius * programmerSettings.largeSphereMultiplier, zoomToAvoidLayers.value))
         { //If the camera is NOT near any specified objects, move out again at the smooth speed.
             //(MUST be defined by a larger sphere than the previous check to prevent flickering)
             dollyDistance = zoomedMax;
-            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * smooth);
+            CamObj.localPosition = Vector3.Lerp(CamObj.localPosition, dollyDir * dollyDistance, Time.deltaTime * programmerSettings.smooth);
         }
     }
 
-    private void RotateToUnblockedPoint()
+    private void RotateToUnblockedPoint(float degPerMove)
     {
-        bool foundOpenSpace = false;
-        for (float offset = 0; offset < 180; offset += 2)
+        //bool foundOpenSpace = false;
+        float interval = Mathf.Abs(degPerMove/2f);
+        interval = Mathf.Max(interval, 0.5f);
+        int i = 0;
+        for (float offset = 0; offset < 90 && i < 20; offset += interval)
         {
             //Positive angle;
-            Quaternion localRotation = Quaternion.Euler(rotX + offset, rotY, 0.0f);
+            Quaternion localRotation = Quaternion.Euler(rotX, rotY + offset, 0.0f);
             transform.rotation = localRotation;
-            if (!Physics.CheckSphere(CamObj.position, smallSphereRadius, sphereLayers.value))
+            if (!Physics.CheckSphere(CamObj.position, collisionSphereRadius, noClippingEverLayers.value))
             {
-                foundOpenSpace = true;
-                rotX = rotX + offset;
+                //foundOpenSpace = true;
+                rotY = rotY + offset;
                 break;
             }
 
             //Positive angle;
-            localRotation = Quaternion.Euler(rotX - offset, rotY, 0.0f);
+            localRotation = Quaternion.Euler(rotX, rotY - offset, 0.0f);
             transform.rotation = localRotation;
-            if (!Physics.CheckSphere(CamObj.position, smallSphereRadius, sphereLayers.value))
+            if (!Physics.CheckSphere(CamObj.position, collisionSphereRadius, noClippingEverLayers.value))
             {
-                foundOpenSpace = true;
-                rotX = rotX - offset;
+                //foundOpenSpace = true;
+                rotY = rotY - offset;
                 break;
             }
+
+            i += 1;
         }
     }
 
@@ -230,9 +247,17 @@ public class CameraGimbal : MonoBehaviour
     private bool PlayerCanSeeBelowPoint()
     {
         RaycastHit hit;
-        if (Physics.Linecast(transform.position, belowPoint.position, out hit, rayLayers.value))
+        if (Physics.Linecast(transform.position, belowPoint.position, out hit, noClippingEverLayers.value))
             return false;
 
         return true;
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.blue;
+        Gizmos.DrawSphere(dollyCamera.transform.position, collisionSphereRadius);
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawWireSphere(dollyCamera.transform.position, collisionSphereRadius * programmerSettings.largeSphereMultiplier);
     }
 }

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelController.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelController.cs
@@ -97,6 +97,12 @@ namespace Player
             {
                 behaviourScripts.ball.ManualUpdate();
             }
+        }
+
+        private void FixedUpdate()
+        {
+            if (PauseMenu.paused || vals.frozen)
+                return;
 
             refs.fCam.UpdateCamPos();
             refs.fCam.UpdateDolly();


### PR DESCRIPTION
- Camera is smooth now (+ setting)
- Completely stops when colliding with specified layers
    - Rotates camera (left/right) until there are no collisions
    - Special check to detect hollow objects
- Zooms forward when colliding with other specified layers
- Can swap between toggle zoom and the old contextual zoom
- Settings are split into programmer and designer and have tooltips

Testing:
* Move in the scene = camera is smooooth
* Change "NoClippingEverLayers" to include a layer (e.g. ground) = camera rotates to never be in objects in that layer
* Change "ZoomToAvoidLayers" to include layer (e.g. trees) = camera pushes forward to avoid (incompatible with previous)
* Turn setting to Toggle Zoom, press middle mouse = camera zooms in
* Look at the settings = confusion should be reduced by >70%

Bugs/Notes:
> Clipping and going inside objects can still happen when zooming - needs discussion.
> Hard stopping is a tiny bit jittery - can be improved but possibly not worth effort.