### PR TITLE
Better Surface Types System, and fixed Air Control with a !

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackage.prefab
@@ -3039,7 +3039,7 @@ MonoBehaviour:
     moveAndClimb: {fileID: 1512199470005858204}
     ball: {fileID: 1512199470005858195}
     foodGrabber: {fileID: 1512199470005858194}
-  debugMessages: 1
+  debugMessages: 0
   animationEvents:
   - trigger: 1
     parameterChange:
@@ -3104,9 +3104,11 @@ MonoBehaviour:
       climbStamPerSec: 0.2
       climbMinAngle: 45
       climbMaxAngle: 130
-      easyClimbTag: EZClimb
-      hardClimbTag: HardClimb
-      noClimbTag: NoClimb
+      defaultSurface: 2
+      EZClimbTag: EZClimb
+      ClimbableTag: Climbable
+      nonClimbableTag: HardClimb
+      slipperyTag: NoClimb
     movement:
       acceleration: 20
       maxSpeed: 3

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelMoveAndClimb.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelMoveAndClimb.cs
@@ -96,6 +96,10 @@ namespace Player
         private void UpdMove()
         {
             //--------------------------MOVEMENT PHYSICS--------------------------//
+            
+            //No moving when on slippery.
+            if (vals.onSlippery)
+                return;
 
             //-----PHASE ONE: GET AND ADJUST INPUT-----//
 
@@ -113,8 +117,7 @@ namespace Player
             if (!Grounded)
                 alteredAcceleration *= settings.M.airControlFactor;
 
-            if (vals.onSlippery)
-                vals.desiredDirection *= 0.1f;
+                //vals.desiredDirection *= 0.1f;
 
             //Calculate the ideal velocity from the input and the acceleration settings.
             Vector3 newVelocity;

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelMoveAndClimb.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelMoveAndClimb.cs
@@ -110,8 +110,11 @@ namespace Player
                 alteredAcceleration *= value;
             }
 
-            if (Grounded)
+            if (!Grounded)
                 alteredAcceleration *= settings.M.airControlFactor;
+
+            if (vals.onSlippery)
+                vals.desiredDirection *= 0.1f;
 
             //Calculate the ideal velocity from the input and the acceleration settings.
             Vector3 newVelocity;
@@ -130,13 +133,7 @@ namespace Player
             //-----PHASE THREE: AVOID EDGES AND SLOW TO MAX SPEED-----//
 
             if (Grounded)
-            {
-                Vector3 preEdgeCodeLatVel = LateralVelocityNew;
-                LateralVelocityNew = AvoidEdgesLinear(preEdgeCodeLatVel);
-                //if (Input.GetButton("Jump"))// && vals.stoppedAtEdge)
-                    //CheckForSpecialJumps();
-                    //FindAndJumpAroundCorner(preEdgeCodeLatVel);
-            }
+                LateralVelocityNew = AvoidEdgesLinear(LateralVelocityNew);
 
             //If the local lateral velocity of the player is above the max speed, do not allow any increases in speed due to input.
             if (LateralVelocityNew.magnitude > alteredMaxSpeed)
@@ -167,7 +164,7 @@ namespace Player
             //-----PHASE FOUR: STOPPING AND FRICTION-----//
 
             //If the player is not trying to move and not jumping, apply stopping force.
-            if (vals.desiredDirection.magnitude < 0.01f && !vals.jumping)
+            if (!vals.jumping && !vals.onSlippery && vals.desiredDirection.magnitude < 0.01f)
             {
                 //Jump to zero velocity when below max speed and on the ground to give more control and prevent gliding.
                 if (Grounded && LateralVelocityNew.magnitude < alteredMaxSpeed * settings.M.haltAtFractionOfMaxSpeed)
@@ -191,11 +188,16 @@ namespace Player
                 TransformedNewVelocity.z = 0;
             }
 
-            //Rotate the character if the lateral velocity is above a threshold, and trigger movement animations.
+            //Rotate the character model if the lateral velocity is above a threshold, and trigger movement animations.
             if (LateralVelocityNew.magnitude > settings.M.maxSpeed * settings.M.turningThreshold)
             {
                 vals.moving = true;
                 ParentRefs.body.rotation = Quaternion.LookRotation(transform.TransformVector(LateralVelocityNew), -transform.forward);
+            }
+            else if (vals.onSlippery && vals.desiredDirection != Vector3.zero)
+            {
+                vals.moving = true;
+                //ParentRefs.body.rotation = Quaternion.LookRotation(transform.TransformVector(vals.desiredDirection), -transform.forward);
             }
             else
                 vals.moving = false;
@@ -262,70 +264,66 @@ namespace Player
             {
                 dir = hitSurface.normal;
                 
-                if (hitSurface.transform.CompareTag(settings.S.easyClimbTag))
+                //Get the angle of this surface.
+                float angle = Vector3.Angle(-dir, Vector3.down);
+
+                //Get the type of this surface.
+                SCRunModeSettings.SCStaminaSettings.SurfaceTypes surface = GetSurfaceType(hitSurface);
+                
+                vals.onSlippery = false;
+
+                //Use stamina and set slippery status based on surface and angle.
+                if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Climbable)
                 {
-                    //No stamina use if EZ climb tag.
+                    if (angle > settings.S.climbMaxAngle)
+                        vals.onSlippery = true;
+                    else if (angle > settings.S.climbMinAngle)
+                    {
+                        if (!ParentRefs.stamina.UseStamina(settings.S.climbStamPerSec * Time.deltaTime))
+                            vals.onSlippery = true;
+                    }
+                }
+                else if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.NonClimbable)
+                {
+                    if (angle > settings.S.climbMinAngle)
+                            vals.onSlippery = true;
+                }
+                else if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Slippery)
+                {
+                    vals.onSlippery = true;
+                }
+
+                //Do animations and behaviour based on if surface is slippery.
+                if (vals.onSlippery)
+                {
+                    PARENT.CallAnimationEvents(SquirrelController.AnimationTrigger.slipping);
+
+                    //Rotate to the surface but DON'T teleport to it.
+                    //CustomIntuitiveSnapRotation(-hitSurface.normal);
                 }
                 else
                 {
-                    //If the angle is greater than the max angle, start using stamina.
-                    float angle = Vector3.Angle(-dir, Vector3.down);
-                    if (angle > settings.S.climbMaxAngle)
-                        ParentRefs.stamina.UseStamina(settings.S.climbStamPerSec * Time.deltaTime * 2f);
+                    ParentRefs.RB.useGravity = false;
+                    if (vals.falling)
+                        PARENT.CallAnimationEvents(SquirrelController.AnimationTrigger.landJump);
 
-
-                    if (hitSurface.transform.CompareTag(settings.S.hardClimbTag))
-                    {
-                        //Large stamina drain above threshold angle, scaling with steepness.
-                        //Climbing fails when no stamina is available.
-                        if (angle > settings.S.climbMinAngle)
-                        {
-                            if (!ParentRefs.stamina.UseStamina(settings.S.climbStamPerSec * Time.deltaTime * 2f)) //* (1f + (angle / 90f) * Time.deltaTime))
-                                return;
-                        }
-                    }
-                    else if (hitSurface.transform.CompareTag(settings.S.noClimbTag))
-                    {
-                        //Climbing instantly fails.
-                        ParentRefs.stamina.UseAllStamina();
-                        return; //Skip the code that disables gravity and sticks the player to the wall.
-                    }
-                    else
-                    {
-                        //Default surface type.
-                        //Small stamina drain above threshold angle.
-                        //Climbing fails when no stamina is available.
-                        if (angle > settings.S.climbMinAngle)
-                        {
-                            if (!ParentRefs.stamina.UseStamina(settings.S.climbStamPerSec * Time.deltaTime))
-                                return; //Skip the code that disables gravity and sticks the player to the wall.
-                        }
-                    }
+                    //Teleport to the surface, and if its angle is too different eliminate the 'up force' to stop player flying off.
+                    TeleportToSurface(hitSurface);
+                    if (Vector3.Angle(vals.lastRotationDir, dir) > settings.WC.wallStickDangerAngle)
+                        vals.eliminateUpForce = true;
                 }
 
-                ParentRefs.RB.useGravity = false;
-                if (vals.falling)
-                {
-                    PARENT.CallAnimationEvents(SquirrelController.AnimationTrigger.landJump);
-                }
+                //Reset falling, jumping and OnSurface values.
                 vals.falling = false;
-
-                //The player counts as on the surface if the raycast hit something.
                 vals.jumping = false;
                 vals.lastOnSurface = Time.time;
 
-                //if the ground is within the wall-stick range, teleport to it, and if its angle is too different eliminate the 'up force' to stop player flying.
-                TeleportToSurface(hitSurface);
-                if (Vector3.Angle(vals.lastRotationDir, dir) > settings.WC.wallStickDangerAngle)
-                {
-                    vals.eliminateUpForce = true;
-                }
-
-                //Used to check the difference in angle on the next frame.
+                //Save the current normal so the difference can be checked next frame.
                 vals.lastRotationDir = dir;
             }
             else if (Time.time > vals.lastOnSurface + settings.WC.noSurfResetTime)
             {
+                //Point feet down and start falling if not on a surface for long enough.
                 CustomIntuitiveSnapRotation(Vector3.down);
                 PARENT.CallAnimationEvents(SquirrelController.AnimationTrigger.falling);
                 vals.falling = true;
@@ -428,6 +426,8 @@ namespace Player
 
             if (FindClimbableWall(out mainHit, distMultiplier))
             {
+                if (!ValidClimb(mainHit))
+                    return false;
                 //Fail the teleport if there is not line-of-sight between the player and the new point.
                 RaycastHit validityCheck;
                 Vector3 checkDir = mainHit.point - refs.climbRotateCheckRay.position;
@@ -573,14 +573,18 @@ namespace Player
             if (Physics.Raycast(firstCast, -ParentRefs.model.transform.up, out hit, (size * settings.J.CornerJumpDepth) + (size * settings.J.SJCheckHeight), settings.WC.rotateToLayers))
             {
                 refs.climbPointDisplay.position = hit.point;
-                if (Vector3.Angle(hit.point, -transform.forward) > settings.J.EdgeDetectAngle)
+                float angle = Vector3.Angle(hit.point, -transform.forward);
+                if (angle > settings.J.EdgeDetectAngle)
                 {
-                    Quaternion oldRot = ParentRefs.model.rotation;
-                    TeleportToSurface(hit);
-                    ParentRefs.model.localRotation = oldRot;
-                    vals.lastCornerVault = Time.time;
-                    vals.eliminateUpForce = true;
-                    return true;
+                    if (ValidClimb(hit))
+                    {
+                        Quaternion oldRot = ParentRefs.model.rotation;
+                        TeleportToSurface(hit);
+                        ParentRefs.model.localRotation = oldRot;
+                        vals.lastCornerVault = Time.time;
+                        vals.eliminateUpForce = true;
+                        return true;
+                    }
                 }
                 return false;
             }
@@ -589,12 +593,15 @@ namespace Player
             Vector3 cornerCheckOrigin = firstCast - ParentRefs.model.transform.up * ((size * settings.J.CornerJumpDepth) + (size * settings.J.SJCheckHeight));
             if (Physics.Raycast(cornerCheckOrigin, -moveDirection, out hit, size * 2f, settings.WC.rotateToLayers))
             {
-                Quaternion oldRot = ParentRefs.model.rotation;
-                TeleportToSurface(hit);
-                ParentRefs.model.localRotation = oldRot;
-                vals.lastCornerVault = Time.time;
-                vals.eliminateUpForce = true;
-                return true;
+                if (ValidClimb(hit))
+                {
+                    Quaternion oldRot = ParentRefs.model.rotation;
+                    TeleportToSurface(hit);
+                    ParentRefs.model.localRotation = oldRot;
+                    vals.lastCornerVault = Time.time;
+                    vals.eliminateUpForce = true;
+                    return true;
+                }
             }
 
             return false;
@@ -614,6 +621,38 @@ namespace Player
             CustomIntuitiveSnapRotation(-hit.normal);
 
             ParentRefs.model.position = oldPos;
+        }
+
+        private bool ValidClimb(RaycastHit hit)
+        {
+            return ValidClimb(Vector3.Angle(hit.normal, Vector3.up), hit);
+        }
+
+        private bool ValidClimb(float angle, RaycastHit hit)
+        {
+            SCRunModeSettings.SCStaminaSettings.SurfaceTypes surface = GetSurfaceType(hit);
+            if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Slippery)
+                return false;
+            if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.NonClimbable && angle > settings.S.climbMinAngle)
+                return false;
+            if (surface == SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Climbable && !ParentRefs.stamina.StaminaAvailable())
+                return false;
+
+            return true;
+        }
+
+        private SCRunModeSettings.SCStaminaSettings.SurfaceTypes GetSurfaceType(RaycastHit hitSurface)
+        {
+            SCRunModeSettings.SCStaminaSettings.SurfaceTypes surface = settings.S.defaultSurface;
+            if (hitSurface.transform.tag == settings.S.EZClimbTag)
+                surface = SCRunModeSettings.SCStaminaSettings.SurfaceTypes.EZClimb;
+            else if (hitSurface.transform.tag == settings.S.ClimbableTag)
+                surface = SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Climbable;
+            else if (hitSurface.transform.tag == settings.S.nonClimbableTag)
+                surface = SCRunModeSettings.SCStaminaSettings.SurfaceTypes.NonClimbable;
+            else if (hitSurface.transform.tag == settings.S.slipperyTag)
+                surface = SCRunModeSettings.SCStaminaSettings.SurfaceTypes.Slippery;
+            return surface;
         }
 
         void OnDrawGizmosSelected()
@@ -682,6 +721,9 @@ namespace Player
             /// <summary> True if the player detected an edge (no surface in front of the player with a relative angle less than 90deg).
             /// Used to allow a corner jump if an appropriate button (dash or jump) is also pressed </summary>
             public bool stoppedAtEdge;
+            /// <summary> True if the player is on a surface they are not allowed to climb.
+            /// Disables control of movement but allows jumping still. </summary>
+            public bool onSlippery;
             /// <summary> The start position of the main edge detect ray.
             /// Used as the starting point to detect corners for more efficiency and flexibility. </summary>
             public Vector3 edgeRayStart;
@@ -763,21 +805,24 @@ namespace Player
                 [Tooltip("Amount of stamina used per second when on a sufficiently steep surface.")]
                 public float climbStamPerSec = 1f;
                 [Tooltip("The angle of a surface for moving on it to be defined as climbing.")]
-                public float climbMinAngle = 1f;
+                public float climbMinAngle = 30f;
                 [Tooltip("The angle of a surface where the player will immediately fall off (except EZ Climb).")]
-                public float climbMaxAngle = 1f;
+                public float climbMaxAngle = 175f;
 
                 [Space]
-                public string easyClimbTag = "EZClimb";
-                public string hardClimbTag = "HardClimb";
-                public string noClimbTag = "NoClimb";
+                public SurfaceTypes defaultSurface = SurfaceTypes.NonClimbable;
+                public enum SurfaceTypes { EZClimb, Climbable, NonClimbable, Slippery }
+                public string EZClimbTag = "EZClimb";
+                public string ClimbableTag = "Climbable";
+                public string nonClimbableTag = "HardClimb";
+                public string slipperyTag = "NoClimb";
             }
 
             [System.Serializable]
             public class SCMoveSettings
             {
                 [Header("Movement Settings")]
-                [Tooltip("Force applied when player holds movement input. Controlls how quickly max speed is reached and how much forces can be countered.")]
+                [Tooltip("Force applied when player holds movement input. Controls how quickly max speed is reached and how much forces can be countered.")]
                 public float acceleration = 20f;
                 [Tooltip("The horizontal speed at which no new acceleration is allowed by the player.")]
                 public float maxSpeed = 3f;

--- a/Capstone-Game/ProjectSettings/TagManager.asset
+++ b/Capstone-Game/ProjectSettings/TagManager.asset
@@ -5,10 +5,10 @@ TagManager:
   serializedVersion: 2
   tags:
   - CameraSolid
-  - CanClimb
-  - HardClimb
-  - NoClimb
   - EZClimb
+  - Climbable
+  - NonClimbable
+  - Slippery
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- Squirrel is now not speedy in the air and slow on the ground (i.e. air-control setting works correctly).
- Surfaces now cause the player to slide off them when they are invalid.
- Jumping and corner-vaulting fail when trying to attach to an invalid surface.
- New 'Default Surface' option: uses chosen surface behavior on any untagged surfaces.

Test:
* Open any scene with the squirrel
* Change either the tag of an object or the default surface in SM&C>Settings>Stamina>default surface
* Try to climb on the surface:
    * EZClimb - Same as the old behavior
    * Climbable - Same, but when at an angle (i.e. climbing) stamina goes down
    * NonClimbable - Same on top, but slide off at climbing angles.
    * Slippery - Slide off at any angle.
 
Bugs/Notes:
> Tags for each surface are using the old names - they can be changed in SM&C>Settings>Stamina to whatever you want, so long as they match.