### PR TITLE
Audio settings are loaded when the game loads

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2123917016201025118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7575136933874560867}
+  - component: {fileID: -4380973460752333832}
+  m_Layer: 0
+  m_Name: LoadSettings
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7575136933874560867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123917016201025118}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4380973460752333832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123917016201025118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b2189de2c39af84439b997b3636c65f1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioMixer: {fileID: 24100000, guid: 34ca02f6309a2f549b4732abe7199d62, type: 2}

--- a/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab.meta
+++ b/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24c091d0101cd7a4092d5d0cfa5cb783
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capstone-Game/Assets/Scenes/TeamScenes/Jordan.unity
+++ b/Capstone-Game/Assets/Scenes/TeamScenes/Jordan.unity
@@ -191,7 +191,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 1923068767}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8d49162572d3ed84c98fa66a642f051b, type: 3}
   m_Name: 
@@ -339,6 +339,63 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1001 &150039904
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2123917016201025118, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_Name
+      value: LoadAudioSettings
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7575136933874560867, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 24c091d0101cd7a4092d5d0cfa5cb783, type: 3}
 --- !u!1 &153672262
 GameObject:
   m_ObjectHideFlags: 0

--- a/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs
+++ b/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.Audio;
+
+public class LoadAudioSettings : MonoBehaviour
+{
+    public AudioMixer audioMixer;
+    private static bool loaded = false;
+
+    private void Start()
+    {
+        if (!loaded)
+        {
+            float musicVolume = PlayerPrefs.GetFloat("musicVolume", 1.0f);
+            float sfxVolume = PlayerPrefs.GetFloat("sfxVolume", 1.0f);
+
+            audioMixer.SetFloat("musicVolume", Mathf.Log10(musicVolume) * 20);
+            audioMixer.SetFloat("sfxVolume", Mathf.Log10(sfxVolume) * 20);
+
+            loaded = true;
+        }
+
+        Destroy(gameObject);
+    }
+}

--- a/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs.meta
+++ b/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b2189de2c39af84439b997b3636c65f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
+++ b/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
@@ -31,8 +31,6 @@ public class OptionsMenu : MonoBehaviour
         selectedResolution = new Resolution();
         selectedResolution.width = PlayerPrefs.GetInt("resolutionWidth", Screen.currentResolution.width);
         selectedResolution.height = PlayerPrefs.GetInt("resolutionHeight", Screen.currentResolution.height);
-
-        Screen.SetResolution(selectedResolution.width, selectedResolution.height, fullscreenToggle.isOn);
     }
 
     private void InitResolutionDropdown()


### PR DESCRIPTION
This PR ensures audio settings are loaded when the game loads. The LoadAudioSettings prefab must be in every scene for this to work. The object is immediately deleted once the settings are loaded so it doesn't clutter the hierarchy while the game is running.

Steps to test:
* View MainMixer in Unity
* Start the game
* Set the volume sliders in the options menu to something that isn't default
* Restart the game
* Notice how the volume of both the music and SFX is set to what it was set to before