### PR TITLE
Food respawns in respawn plane

### DIFF
--- a/Capstone-Game/Assets/Scripts/Food.cs
+++ b/Capstone-Game/Assets/Scripts/Food.cs
@@ -4,9 +4,11 @@ using UnityEngine;
 public class Food : MonoBehaviour
 {
     private Vector3 spawnPoint;
+    private Quaternion spawnRotation;
     private static List<Food> foodList = new List<Food>();
 
     public float respawnTimer;
+    private Rigidbody rb;
 
 
     private void Awake()
@@ -14,6 +16,8 @@ public class Food : MonoBehaviour
         foodList.Add(this);
 
         spawnPoint = transform.position;
+        spawnRotation = transform.rotation;
+        rb = GetComponent<Rigidbody>();
     }
 
 
@@ -41,7 +45,8 @@ public class Food : MonoBehaviour
     {
         gameObject.SetActive(true);
         gameObject.transform.position = spawnPoint;
-
+        gameObject.transform.rotation = spawnRotation;
+        rb.velocity = Vector3.zero;
     }
 
 }

--- a/Capstone-Game/Assets/Scripts/Respawn/RespawnPlane.cs
+++ b/Capstone-Game/Assets/Scripts/Respawn/RespawnPlane.cs
@@ -3,10 +3,12 @@ using UnityEngine;
 public class RespawnPlane : MonoBehaviour
 {
     private Player.SquirrelController squirrel;
+    private Food[] foods;
 
     private void Start()
     {
         squirrel = FindObjectOfType<Player.SquirrelController>();
+        foods = FindObjectsOfType<Food>();
     }
 
     private void Update()
@@ -14,6 +16,14 @@ public class RespawnPlane : MonoBehaviour
         if (squirrel.transform.position.y < transform.position.y)
         {
             squirrel.transform.position = Checkpoint.getRespawnPoint();
+        }
+
+        foreach (Food food in foods)
+        {
+            if (food.transform.position.y < transform.position.y)
+            {
+                food.respawnSelf();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR makes food respawn at their initial location when they fall below a respawn plane.

Known issues:
* This doesn't work for food NPCs create to give to the squirrel.
* The food may roll in a slightly different way when it respawns because of the way the physics works. I have done my best to avoid this by resetting their position, rotation and velocity on respawn.

Steps to test:
* Be on any scene with food and a respawn plane
* Throw the food into the respawn plane

https://user-images.githubusercontent.com/62001991/135740922-cdebe3a6-1ed9-4ca8-a278-4e89a5646d30.mp4
