### PR TITLE
Fix error caused by koalas deleting food from their assigned food area

### DIFF
--- a/Capstone-Game/Assets/Scripts/Dialogue/NPCDialogue.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/NPCDialogue.cs
@@ -46,7 +46,7 @@ public class NPCDialogue : MonoBehaviour
 
             for (int i = 0; i < objectsToRemove; i++)
             {
-                GameObject.Destroy(objects[i]);
+                objects[i].SetActive(false);
             }
 
             GameObject.Destroy(foodArea.gameObject);


### PR DESCRIPTION
This error occurred because I went against the assumption that food will never be created or destroyed mid-game. The respawn plane tried to check if any food was below it but some were null because they were destroyed, so it produced an error.

Steps to test:
1. Be on ISLAND scene
2. Collect 5 or more food
3. Give it to the Koala on the beach
4. Make sure error no longer occurs when the koala takes the food