### PR TITLE
Object area automatically disables its mesh renderer on start

### DIFF
--- a/Capstone-Game/Assets/Scripts/Misc/ObjectArea.cs
+++ b/Capstone-Game/Assets/Scripts/Misc/ObjectArea.cs
@@ -16,6 +16,12 @@ public class ObjectArea : MonoBehaviour
     private void Start()
     {
         trigger = GetComponent<Collider>();
+
+        MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
+        if (meshRenderer != null)
+        {
+            meshRenderer.enabled = false;
+        }
     }
 
     private void Update()


### PR DESCRIPTION
Steps to reproduce:
1. Put an object area in a scene and make sure its mesh renderer is enabled
2. Start the game
3. *waves magic wand*
4. It's disappeared