### PR TITLE
Balance and lower default volume

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/LoadAudioSettings.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 7575136933874560867}
   - component: {fileID: -4380973460752333832}
   m_Layer: 0
-  m_Name: LoadSettings
+  m_Name: LoadAudioSettings
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -44,3 +44,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   audioMixer: {fileID: 24100000, guid: 34ca02f6309a2f549b4732abe7199d62, type: 2}
+  maxMusicVolume: 1
+  maxSfxVolume: 0.2
+  initialMusicVolume: 0.5
+  initialSfxVolume: 0.5

--- a/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs
+++ b/Capstone-Game/Assets/Scripts/LoadAudioSettings.cs
@@ -6,19 +6,31 @@ public class LoadAudioSettings : MonoBehaviour
     public AudioMixer audioMixer;
     private static bool loaded = false;
 
+    [Header("APPLY CHANGES TO PREFAB!")]
+
+    [Range(0, 1)]
+    public float maxMusicVolume = 1.0f;
+
+    [Range(0, 1)]
+    public float maxSfxVolume = 1.0f;
+
+    [Range(0, 1)]
+    public float initialMusicVolume = 0.5f;
+
+    [Range(0, 1)]
+    public float initialSfxVolume = 0.5f;
+
+
     private void Start()
     {
-        if (!loaded)
-        {
-            float musicVolume = PlayerPrefs.GetFloat("musicVolume", 1.0f);
-            float sfxVolume = PlayerPrefs.GetFloat("sfxVolume", 1.0f);
+        if (loaded) return;
 
-            audioMixer.SetFloat("musicVolume", Mathf.Log10(musicVolume) * 20);
-            audioMixer.SetFloat("sfxVolume", Mathf.Log10(sfxVolume) * 20);
+        float musicVolume = PlayerPrefs.GetFloat("musicVolume", initialMusicVolume);
+        float sfxVolume = PlayerPrefs.GetFloat("sfxVolume", initialSfxVolume);
 
-            loaded = true;
-        }
+        audioMixer.SetFloat("musicVolume", Mathf.Log10(musicVolume * maxMusicVolume) * 20);
+        audioMixer.SetFloat("sfxVolume", Mathf.Log10(sfxVolume * maxSfxVolume) * 20);
 
-        Destroy(gameObject);
+        loaded = true;
     }
 }

--- a/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
+++ b/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
@@ -15,17 +15,20 @@ public class OptionsMenu : MonoBehaviour
     private Resolution[] resolutions;
     private Resolution selectedResolution;
     public Animation anim;
+    private LoadAudioSettings audioSettings;
 
     private void Start()
     {
+        audioSettings = GameObject.FindObjectOfType<LoadAudioSettings>();
+
         LoadSettings();
         InitResolutionDropdown();
     }
 
     private void LoadSettings()
     {
-        musicVolumeSlider.value = PlayerPrefs.GetFloat("musicVolume", 1.0f);
-        sfxVolumeSlider.value = PlayerPrefs.GetFloat("sfxVolume", 1.0f);
+        musicVolumeSlider.value = PlayerPrefs.GetFloat("musicVolume", audioSettings.initialMusicVolume);
+        sfxVolumeSlider.value = PlayerPrefs.GetFloat("sfxVolume", audioSettings.initialSfxVolume);
         fullscreenToggle.isOn = PlayerPrefs.GetInt("fullscreen", 1) == 1;
 
         selectedResolution = new Resolution();
@@ -61,13 +64,13 @@ public class OptionsMenu : MonoBehaviour
 
     public void SetMusicVolume(float volume)
     {
-        audioMixer.SetFloat("musicVolume", Mathf.Log10(volume) * 20);
+        audioMixer.SetFloat("musicVolume", Mathf.Log10(volume * audioSettings.maxMusicVolume) * 20);
         PlayerPrefs.SetFloat("musicVolume", volume);
     }
 
     public void SetSFXVolume(float volume)
     {
-        audioMixer.SetFloat("sfxVolume", Mathf.Log10(volume) * 20);
+        audioMixer.SetFloat("sfxVolume", Mathf.Log10(volume * audioSettings.maxSfxVolume) * 20);
         PlayerPrefs.SetFloat("sfxVolume", volume);
     }
 


### PR DESCRIPTION
This PR balances music and SFX volume and allows for customisation for the max and initial volume levels.

Steps to test:
* Be on any scene with music/SFX (ISLAND scene is best)
* Open options menu and check if initial slider positions are half way
  * This might not work since the game remembers your settings. I tested this by calling `PlayerPrefs.DeleteAll();` before the code that loads audio settings in LoadAudioSettings.cs
* Fiddle around with the exposed properties in the LoadAudioSettings prefab and wiggle around the volume sliders to apply them

IF YOU CHANGE THE INITIAL/MAX VOLUME, MAKE SURE TO APPLY IT TO THE PREFAB SO IT UPDATES IN EVERY SCENE!!!!!