### PR TITLE
Food no longer highlights when you are full

### DIFF
--- a/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
@@ -69,7 +69,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
         if (PauseMenu.paused) return;
 
         GameObject prevNearestFood = nearestFood;
-        nearestFood = GetNearestFood();
+        nearestFood = CanEatFood() ? GetNearestFood() : null;
 
         if (prevNearestFood != nearestFood)
         {


### PR DESCRIPTION
This PR doesn't highlight food when you are full and cannot eat any more food.

Steps to test:
1. Be on any scene with food
2. Eat as much food as you can
3. Ensure food no longer highlights