### PR TITLE
Fixed game freezing when skipping intro

### DIFF
--- a/Capstone-Game/Assets/Scripts/Intro/IntroSkip.cs
+++ b/Capstone-Game/Assets/Scripts/Intro/IntroSkip.cs
@@ -9,12 +9,16 @@ public class IntroSkip : MonoBehaviour
     public HideUIElementAfterDelay skipText;
 
     private VideoPlayer videoPlayer;
+    private AsyncOperation asyncLoad;
 
     private void Start()
     {
         videoPlayer = GetComponent<VideoPlayer>();
         videoPlayer.loopPointReached += VideoEnded;
         Cursor.visible = false;
+
+        asyncLoad = SceneManager.LoadSceneAsync(SceneManager.GetActiveScene().buildIndex + 1);
+        asyncLoad.allowSceneActivation = false;
     }
 
     private void Update()
@@ -47,6 +51,6 @@ public class IntroSkip : MonoBehaviour
 
     private void NextScene()
     {
-        SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex + 1);
+        asyncLoad.allowSceneActivation = true;
     }
 }


### PR DESCRIPTION
Steps to test:
1. Build and run the game
2. Watch the cutscene for a bit to allow the island scene to load in the background
3. Press space to immediately load into the island scene
4. If you press space immediately when the intro starts playing, you will load into the island scene when it has finished loading without the game freezing