### PR TITLE
Reduced initial camera sensitivity

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackageW_Controllers.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackageW_Controllers.prefab
@@ -2707,7 +2707,7 @@ MonoBehaviour:
   targetInvisibleRadius: 0.15
   translationSmoothing: 0.01
   cameraSmoothThreshold: 0
-  cameraSensitivity: 250
+  cameraSensitivity: 150
   programmerSettings:
     smooth: 8.7
     upperWorldClampAngle: 70
@@ -3291,7 +3291,6 @@ MonoBehaviour:
     ballShadowFOV: 30
     giantShadowFOV: 100
   debugMessages: 0
-  updateInFixed: 1
   animationEvents:
   - trigger: 1
     type: 1

--- a/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
+++ b/Capstone-Game/Assets/Scripts/Menus/OptionsMenu.cs
@@ -46,7 +46,7 @@ public class OptionsMenu : MonoBehaviour
         selectedResolution.width = PlayerPrefs.GetInt("resolutionWidth", Screen.currentResolution.width);
         selectedResolution.height = PlayerPrefs.GetInt("resolutionHeight", Screen.currentResolution.height);
 
-        cameraSensSlider.value = PlayerPrefs.GetFloat("cameraSensitivity", 250);
+        cameraSensSlider.value = PlayerPrefs.GetFloat("cameraSensitivity", 150);
     }
 
     private void InitResolutionDropdown()

--- a/Capstone-Game/Assets/Scripts/Player/CameraGimbal.cs
+++ b/Capstone-Game/Assets/Scripts/Player/CameraGimbal.cs
@@ -40,7 +40,7 @@ public class CameraGimbal : MonoBehaviour
     public float translationSmoothing = 0.1f;
     public bool cameraSmoothThreshold = false;
     [Tooltip("How fast the camera rotates when you move your mouse/joystick")]
-    public float cameraSensitivity = 250.0f;
+    public float cameraSensitivity = 150.0f;
 
     private Transform CamObj
     {

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelController.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelController.cs
@@ -83,7 +83,7 @@ namespace Player
             vals.lastOnSurface = -10;
             vals.preFreezeConstraints = refs.RB.constraints;
 
-            refs.fCam.SetSensitivity(PlayerPrefs.GetFloat("cameraSensitivity", 250));
+            refs.fCam.SetSensitivity(PlayerPrefs.GetFloat("cameraSensitivity", 150));
 
             if (behaviourScripts.moveAndClimb == null)
                 behaviourScripts.moveAndClimb = GetComponent<SquirrelMoveAndClimb>();
@@ -312,7 +312,7 @@ namespace Player
 
         private void OnResume()
         {
-            refs.fCam.SetSensitivity(PlayerPrefs.GetFloat("cameraSensitivity", 250));
+            refs.fCam.SetSensitivity(PlayerPrefs.GetFloat("cameraSensitivity", 150));
         }
 
         public void CallEvents(EventTrigger trigger)


### PR DESCRIPTION
This was done in response to playtester feedback. Let's just ignore how many hardcoded variables there are to change default sensitivity. 🙈 

Steps to test:
1. Call `PlayerPrefs.DeleteAll()` in the awake function of the squirrel to clear saved preferences
2. Play on ISLAND scene
3. Notice how the default camera sensitivity is different
4. Check that the main menu and pause menu options slider for camera sensitivity is correct (positioned 1/4)