### PR TITLE
Fixed roundabout rotation

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/Objects/Artificial/Roundabout.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Objects/Artificial/Roundabout.prefab
@@ -144,6 +144,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ef87d94efad60644abe32c881b7b5971, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  speed: 30
 --- !u!54 &5929009393593082444
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Capstone-Game/Assets/Scripts/Misc/Roundabout.cs
+++ b/Capstone-Game/Assets/Scripts/Misc/Roundabout.cs
@@ -1,19 +1,12 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class Roundabout : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
-    {
-        transform.Rotate(0, 0, 0 * Time.deltaTime);
-    }
+    [Tooltip("How fast the roundabout rotates")]
+    public float speed = 30.0f;
 
-    // Update is called once per frame
     void Update()
     {
-        transform.Rotate(0, 2, 0 * Time.deltaTime);
-
+        transform.Rotate(0, speed * Time.deltaTime, 0);
     }
 }


### PR DESCRIPTION
The roundabout no longer spins out of control. The speed can be configured in the prefab.

Steps to test:
1. Be on ISLAND scene
2. Go to roundabout
3. Tweak the speed of the roundabout