### PR TITLE
Added inspector toggle for eating/spitting while in ball form

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackageW_Controllers.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/Player/PlayerPackageW_Controllers.prefab
@@ -3286,12 +3286,12 @@ MonoBehaviour:
     sizeMultiplier: 8
     cameraMultiplier: 3
     squishinessMultiplier: 0.5
+    inGiantMode: 0
   shadowSettings:
     runShadowFOV: 20
     ballShadowFOV: 30
     giantShadowFOV: 100
   debugMessages: 0
-  updateInFixed: 1
   animationEvents:
   - trigger: 1
     type: 1
@@ -3699,6 +3699,7 @@ MonoBehaviour:
   throwDelayDivisor: 1.5
   minThrowDelay: 0.2
   throwEnabledOverride: 1
+  canThrowInBallForm: 1
   pickupEvent:
     m_PersistentCalls:
       m_Calls:

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
@@ -54,6 +54,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
     public float minThrowDelay = 0.2f;
     [Tooltip("When disabled, throwing food is disabled")]
     public bool throwEnabledOverride = true;
+    public bool canThrowInBallForm = false;
     private float throwTime = 0.0f;
     private float throwDelay;
 
@@ -236,6 +237,8 @@ public class SquirrelFoodGrabber : MonoBehaviour
             throwEnabledOverride &&
             // Player isn't interacting with an NPC
             !npcInteractionManager.isInteracting &&
+            // In normal squirrel form
+            (canThrowInBallForm || normalMouth.gameObject.activeInHierarchy) &&
             // Player has food to spit
             (foodStack.Count > 0 ||
             // Player has giant acorn

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
@@ -40,6 +40,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
     public Material highlightMaterial;
     [Tooltip("When disabled, picking up food is disabled")]
     public bool pickupEnabledOverride = true;
+    public bool canEatInBallForm = false;
 
     [Header("Throwing up food")]
 
@@ -224,7 +225,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
             // Pickup cooldown has ended
             Time.time >= pickupTime &&
             // In normal squirrel form
-            normalMouth.gameObject.activeInHierarchy &&
+            (canEatInBallForm || normalMouth.gameObject.activeInHierarchy) &&
             // Not holding the giant acorn
             giantAcorn == null
         );

--- a/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
+++ b/Capstone-Game/Assets/Scripts/Player/SquirrelFoodGrabber.cs
@@ -40,6 +40,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
     public Material highlightMaterial;
     [Tooltip("When disabled, picking up food is disabled")]
     public bool pickupEnabledOverride = true;
+    [Tooltip("Whether the player can pick up food while in ball form")]
     public bool canEatInBallForm = false;
 
     [Header("Throwing up food")]
@@ -55,6 +56,7 @@ public class SquirrelFoodGrabber : MonoBehaviour
     public float minThrowDelay = 0.2f;
     [Tooltip("When disabled, throwing food is disabled")]
     public bool throwEnabledOverride = true;
+    [Tooltip("Whether the player can throw food while in ball form")]
     public bool canThrowInBallForm = false;
     private float throwTime = 0.0f;
     private float throwDelay;


### PR DESCRIPTION
Added this to give designers the option to change this. Disabling spitting while in ball form will probably break the big acorn ending. There's probably never a reason to enable eating while in ball form but I added it for completeness.

Steps to test:
1. Be on any scene with food
2. Eat food to turn into ball form
3. Fiddle around with the toggles in SquirrelFoodGrabber