### PR TITLE
Added Koala dialogue sounds

### DIFF
--- a/Capstone-Game/Assets/Resources/Prefabs/UI/Dialogue/DialogueBox.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/UI/Dialogue/DialogueBox.prefab
@@ -16,6 +16,7 @@ GameObject:
   - component: {fileID: 1086128863157782398}
   - component: {fileID: 7420557728162551993}
   - component: {fileID: 3604566121284104260}
+  - component: {fileID: 612972850034307231}
   m_Layer: 5
   m_Name: DialogueBox
   m_TagString: Untagged
@@ -158,6 +159,102 @@ MonoBehaviour:
   m_DynamicPixelsPerUnit: 1
   m_PresetInfoIsWorld: 0
 --- !u!82 &3604566121284104260
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128778952771703337}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: -3983698746238741912, guid: 34ca02f6309a2f549b4732abe7199d62, type: 2}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!82 &612972850034307231
 AudioSource:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Capstone-Game/Assets/Resources/Prefabs/UI/Dialogue/DialogueBox.prefab
+++ b/Capstone-Game/Assets/Resources/Prefabs/UI/Dialogue/DialogueBox.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 2896876885568496721}
   - component: {fileID: 1086128863157782398}
   - component: {fileID: 7420557728162551993}
+  - component: {fileID: 3604566121284104260}
   m_Layer: 5
   m_Name: DialogueBox
   m_TagString: Untagged
@@ -129,7 +130,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -156,6 +157,102 @@ MonoBehaviour:
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
   m_PresetInfoIsWorld: 0
+--- !u!82 &3604566121284104260
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1128778952771703337}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: -3983698746238741912, guid: 34ca02f6309a2f549b4732abe7199d62, type: 2}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1128778952822745502
 GameObject:
   m_ObjectHideFlags: 0

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 1.asset
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 1.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04273a48ccd3fc44983e66b6acdba9a3, type: 3}
   m_Name: Beach2Intro 1
   m_EditorClassIdentifier: 
+  speakSound: {fileID: 8300000, guid: 5c28d22db28d7684f9306b9ed047c836, type: 3}
   entries:
   - text: '*shock and awe*'
     sprite: {fileID: 21300000, guid: 300dadbdf3fc5254d911a403452005c5, type: 3}

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 2.asset
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 2.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04273a48ccd3fc44983e66b6acdba9a3, type: 3}
   m_Name: Beach2Intro 2
   m_EditorClassIdentifier: 
+  speakSound: {fileID: 8300000, guid: 5c28d22db28d7684f9306b9ed047c836, type: 3}
   entries:
   - text: '*shock and awe*'
     sprite: {fileID: 21300000, guid: 300dadbdf3fc5254d911a403452005c5, type: 3}

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 3.asset
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro 3.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 04273a48ccd3fc44983e66b6acdba9a3, type: 3}
   m_Name: Beach2Intro 3
   m_EditorClassIdentifier: 
+  speakSound: {fileID: 8300000, guid: 5c28d22db28d7684f9306b9ed047c836, type: 3}
   entries:
   - text: '*shock and awe*'
     sprite: {fileID: 21300000, guid: 300dadbdf3fc5254d911a403452005c5, type: 3}

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro.asset
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/Dialogue/Beach2/Beach2Intro.asset
@@ -15,16 +15,21 @@ MonoBehaviour:
   entries:
   - text: '*shock and awe*'
     sprite: {fileID: 21300000, guid: 300dadbdf3fc5254d911a403452005c5, type: 3}
+    audioClipSet: {fileID: 11400000, guid: c880acc321221394fb9ec6c1b162b352, type: 2}
   - text: "It\u2019s so HUGE! So much bigger up close...man!\r"
     sprite: {fileID: 21300000, guid: 201902786ebf009408126b60f49b39be, type: 3}
+    audioClipSet: {fileID: 11400000, guid: c880acc321221394fb9ec6c1b162b352, type: 2}
   - text: 'Thank you so much, little guy. We''re going to have the biggest feast
       tonight!! How do you like what I did with the place?
 
 '
     sprite: {fileID: 21300000, guid: 201902786ebf009408126b60f49b39be, type: 3}
+    audioClipSet: {fileID: 11400000, guid: c880acc321221394fb9ec6c1b162b352, type: 2}
   - text: "Speaking of\u2026 I\u2019ve got some people to introduce you to who I
       think will want to give you a big bloody hug!\r\n"
     sprite: {fileID: 21300000, guid: f2b47b7936547f34689640c321e86f82, type: 3}
+    audioClipSet: {fileID: 11400000, guid: c880acc321221394fb9ec6c1b162b352, type: 2}
   - text: "OI EVERYONE, GET OVER HERE\u2026 WE\u2019VE GOT A VERY SPECIAL GUEST FOR
       A VERY SPECIAL DINNER TONIGHT!\r\n"
     sprite: {fileID: 21300000, guid: f523a4645592bb64486ae6c1dfe4fc8c, type: 3}
+    audioClipSet: {fileID: 11400000, guid: c880acc321221394fb9ec6c1b162b352, type: 2}

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds.meta
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9814c0be5a185bc40b3ba2fd182088b5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds/KoalaSounds.asset
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds/KoalaSounds.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d03b87e2599e1aa4cad9378dc813e3f0, type: 3}
+  m_Name: KoalaSounds
+  m_EditorClassIdentifier: 
+  audioClips:
+  - {fileID: 8300000, guid: 5c28d22db28d7684f9306b9ed047c836, type: 3}
+  - {fileID: 8300000, guid: b92bad03c16fcce4cbdf2f44a52b8ef8, type: 3}
+  - {fileID: 8300000, guid: f7e2505ce317bac45890d98083847eff, type: 3}
+  minimumPitch: 0.9
+  maximumPitch: 1.1

--- a/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds/KoalaSounds.asset.meta
+++ b/Capstone-Game/Assets/Resources/ScriptableObjects/KoalaSounds/KoalaSounds.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c880acc321221394fb9ec6c1b162b352
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capstone-Game/Assets/Scenes/TeamScenes/Jordan.unity
+++ b/Capstone-Game/Assets/Scenes/TeamScenes/Jordan.unity
@@ -1464,7 +1464,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   initialDialogue: {fileID: 11400000, guid: 17260d2744b001e499842b2d136078a4, type: 2}
-  preFoodDialogue: {fileID: 11400000, guid: ccc5feb1118d5134bb6c028e47a8841f, type: 2}
+  preFoodDialogue: {fileID: 11400000, guid: 17260d2744b001e499842b2d136078a4, type: 2}
   foodDialogue: {fileID: 11400000, guid: e5877839af0997d4a9975906be664fde, type: 2}
   postFoodDialogue: {fileID: 11400000, guid: 9bafeb87690de06469f4e805643168a3, type: 2}
   foodArea: {fileID: 720750694}

--- a/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Audio Clip Set", menuName = "Audio Clip Set")]
+public class AudioClipSet : ScriptableObject
+{
+    public AudioClip[] audioClips;
+
+    public AudioClip GetRandomAudioClip()
+    {
+        return audioClips[Random.Range(0, audioClips.Length - 1)];
+    }
+}

--- a/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs
@@ -5,8 +5,19 @@ public class AudioClipSet : ScriptableObject
 {
     public AudioClip[] audioClips;
 
+    [Tooltip("The minimum random pitch of the audio clips")]
+    public float minimumPitch = 1.0f;
+
+    [Tooltip("The maximum random pitch of the audio clips")]
+    public float maximumPitch = 1.0f;
+
     public AudioClip GetRandomAudioClip()
     {
         return audioClips[Random.Range(0, audioClips.Length - 1)];
+    }
+
+    public float getRandomPitch()
+    {
+        return Random.Range(minimumPitch, maximumPitch);
     }
 }

--- a/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs.meta
+++ b/Capstone-Game/Assets/Scripts/Dialogue/AudioClipSet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d03b87e2599e1aa4cad9378dc813e3f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Capstone-Game/Assets/Scripts/Dialogue/Dialogue.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/Dialogue.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "New Dialogue", menuName = "Dialogue")]
 public class Dialogue : ScriptableObject
 {
+    [Tooltip("If set, this is the set of sounds to randomly pick from for every letter spoken in all dialogue entries")]
+    public AudioClipSet audioClipSet;
+
     [Tooltip("A list of dialogue entries")]
     public DialogueEntry[] entries;
 }

--- a/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
@@ -102,7 +102,8 @@ public class DialogueBox : MonoBehaviour
 
         float t = 0;
         int charIndex = 0;
-        DialogueEntry dialogueEntry = dialogue.GetDialogue().entries[index];
+        Dialogue currentDialogue = dialogue.GetDialogue();
+        DialogueEntry dialogueEntry = currentDialogue.entries[index];
         string textToType = dialogueEntry.text;
 
         while (charIndex < textToType.Length)
@@ -124,7 +125,12 @@ public class DialogueBox : MonoBehaviour
                 }
             }
 
-            PlaySpeakingSound(dialogueEntry);
+            if (!audioSource.isPlaying)
+            {
+                AudioClipSet audioClipSet = dialogueEntry.audioClipSet ?? currentDialogue.audioClipSet;
+                audioSource.pitch = audioClipSet.getRandomPitch();
+                audioSource.PlayOneShot(audioClipSet.GetRandomAudioClip());
+            }
 
             yield return null;
         }
@@ -132,16 +138,6 @@ public class DialogueBox : MonoBehaviour
         text.text = textToType;
         nextText.enabled = true;
         isTyping = false;
-    }
-
-    private void PlaySpeakingSound(DialogueEntry dialogueEntry)
-    {
-        if (!audioSource.isPlaying)
-        {
-            AudioClipSet audioClipSet = dialogueEntry.audioClipSet;
-            audioSource.pitch = audioClipSet.getRandomPitch();
-            audioSource.PlayOneShot(audioClipSet.GetRandomAudioClip());
-        }
     }
 
     public void NextSentence()

--- a/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
@@ -5,6 +5,7 @@ using UnityEngine.UI;
 using TMPro;
 
 [RequireComponent(typeof(CanvasGroup))]
+[RequireComponent(typeof(AudioSource))]
 public class DialogueBox : MonoBehaviour
 {
     [Tooltip("Reference to the dialogue box title text element")]
@@ -48,8 +49,7 @@ public class DialogueBox : MonoBehaviour
         canvasGroup = GetComponent<CanvasGroup>();
         canvasGroup.alpha = 0;
 
-        audioSource = gameObject.AddComponent<AudioSource>();
-        audioSource.playOnAwake = false;
+        audioSource = GetComponent<AudioSource>();
     }
 
     private void Update()
@@ -118,19 +118,13 @@ public class DialogueBox : MonoBehaviour
             {
                 text.text = textToType.Substring(0, i + 1);
 
-                bool isLast = i >= textToType.Length - 1;
-
-                if (!isLast && !audioSource.isPlaying)
-                {
-                    AudioClip audioClip = dialogueEntry.audioClipSet.GetRandomAudioClip();
-                    audioSource.PlayOneShot(audioClip);
-                }
-
                 if (i < textToType.Length - 1 && IsPunctuation(textToType[i], out float waitTime) && !IsPunctuation(textToType[i + 1], out _))
                 {
                     yield return new WaitForSeconds(waitTime);
                 }
             }
+
+            PlaySpeakingSound(dialogueEntry);
 
             yield return null;
         }
@@ -138,6 +132,16 @@ public class DialogueBox : MonoBehaviour
         text.text = textToType;
         nextText.enabled = true;
         isTyping = false;
+    }
+
+    private void PlaySpeakingSound(DialogueEntry dialogueEntry)
+    {
+        if (!audioSource.isPlaying)
+        {
+            AudioClipSet audioClipSet = dialogueEntry.audioClipSet;
+            audioSource.pitch = audioClipSet.getRandomPitch();
+            audioSource.PlayOneShot(audioClipSet.GetRandomAudioClip());
+        }
     }
 
     public void NextSentence()

--- a/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/DialogueBox.cs
@@ -35,6 +35,7 @@ public class DialogueBox : MonoBehaviour
     private Coroutine typingCoroutine;
 
     private CanvasGroup canvasGroup;
+    private AudioSource audioSource;
     private bool wasDialogueOpen = false;
     private Dictionary<HashSet<char>, float> punctuations = new Dictionary<HashSet<char>, float>()
     {
@@ -46,6 +47,9 @@ public class DialogueBox : MonoBehaviour
     {
         canvasGroup = GetComponent<CanvasGroup>();
         canvasGroup.alpha = 0;
+
+        audioSource = gameObject.AddComponent<AudioSource>();
+        audioSource.playOnAwake = false;
     }
 
     private void Update()
@@ -98,7 +102,8 @@ public class DialogueBox : MonoBehaviour
 
         float t = 0;
         int charIndex = 0;
-        string textToType = dialogue.GetDialogue().entries[index].text;
+        DialogueEntry dialogueEntry = dialogue.GetDialogue().entries[index];
+        string textToType = dialogueEntry.text;
 
         while (charIndex < textToType.Length)
         {
@@ -114,6 +119,13 @@ public class DialogueBox : MonoBehaviour
                 text.text = textToType.Substring(0, i + 1);
 
                 bool isLast = i >= textToType.Length - 1;
+
+                if (!isLast && !audioSource.isPlaying)
+                {
+                    AudioClip audioClip = dialogueEntry.audioClipSet.GetRandomAudioClip();
+                    audioSource.PlayOneShot(audioClip);
+                }
+
                 if (i < textToType.Length - 1 && IsPunctuation(textToType[i], out float waitTime) && !IsPunctuation(textToType[i + 1], out _))
                 {
                     yield return new WaitForSeconds(waitTime);

--- a/Capstone-Game/Assets/Scripts/Dialogue/DialogueEntry.cs
+++ b/Capstone-Game/Assets/Scripts/Dialogue/DialogueEntry.cs
@@ -9,4 +9,7 @@ public class DialogueEntry
 
     [Tooltip("The character sprite to display above the dialogue box")]
     public Sprite sprite;
+
+    [Tooltip("The set of sounds to randomly pick from for every letter spoken in this dialogue")]
+    public AudioClipSet audioClipSet;
 }


### PR DESCRIPTION
This PR adds sounds for dialogue. You can specify an audio clip set for each dialogue as a whole or for individual dialogue entries. Audio clip sets for individual dialogue entries are prioritised over the one for the entire dialogue.

I added KoalaSounds audio clip set for testing. I have used this arbitrarily in Beach2Intro dialogue.

Creating an audio clip set:
1. Right-click in Unity project directory
2. Create
3. Audio Clip Set (at top)

Steps to test:
1. Be on Jordan scene
2. Speak with big capsule
3. Hear sounds